### PR TITLE
fix for asdf:monolithic-compile-bundle-op in abcl

### DIFF
--- a/abcl/custom.lisp
+++ b/abcl/custom.lisp
@@ -1,0 +1,4 @@
+; the existence of this file makes
+; (asdf:operate 'asdf:monolithic-compile-bundle-op "cl-store")
+; work in abcl
+(in-package :cl-store)


### PR DESCRIPTION
ABCL produces a warning when loading this system:

`
; Caught SIMPLE-WARNING:
;   compiling #<CL-STORE.SYSTEM:NON-REQUIRED-FILE "cl-store" "custom"> completed without its input file #P"/Volumes/vibhu/Downloads/cl-store-master/abcl/custom.lisp" or its output file #P"/Volumes/vibhu/.cache/common-lisp/abcl-1.4.0-fasl42-macosx-x64/Volumes/vibhu/Downloads/cl-store-master/abcl/custom.abcl"
`

and also an error if you do:

`(asdf:operate 'asdf:monolithic-compile-bundle-op "cl-store")`

`#<THREAD "interpreter" {38CDE13}>: Debugger invoked on condition of type FILE-ERROR`
`  No file found: org.armedbear.lisp.Pathname@8a53e04`

So something about the non-required-file machinery in cl-store.asd is not working for abcl. Perhaps we need to define another method on the class, non-required-file. I can't tell.

This commit works around the problem.
