### PR TITLE
Change some sb-kernel:: package prefixes to sb-kernel:

### DIFF
--- a/sbcl/custom-xml.lisp
+++ b/sbcl/custom-xml.lisp
@@ -16,23 +16,23 @@
 
 (defstore-xml (obj single-float stream)
   (with-tag ("SINGLE-FLOAT" stream)
-    (princ-and-store "BITS" (sb-kernel::single-float-bits obj)
+    (princ-and-store "BITS" (sb-kernel:single-float-bits obj)
                      stream)))
 
 (defrestore-xml (single-float stream)
-  (sb-kernel::make-single-float
-   (restore-first (get-child "BITS" stream))))
+   (sb-kernel:make-single-float
+    (restore-first (get-child "BITS" stream))))
 
 (defstore-xml (obj double-float stream)
   (with-tag ("DOUBLE-FLOAT" stream)
-    (princ-and-store "HIGH-BITS" (sb-kernel::double-float-high-bits obj)
+    (princ-and-store "HIGH-BITS" (sb-kernel:double-float-high-bits obj)
                      stream)
-    (princ-and-store "LOW-BITS" (sb-kernel::double-float-low-bits obj)
+    (princ-and-store "LOW-BITS" (sb-kernel:double-float-low-bits obj)
                      stream)))
 
 (defrestore-xml (double-float stream)
-  (sb-kernel::make-double-float (restore-first (get-child "HIGH-BITS" stream))
-                                (restore-first (get-child "LOW-BITS" stream))))
+  (sb-kernel:make-double-float (restore-first (get-child "HIGH-BITS" stream))
+			       (restore-first (get-child "LOW-BITS" stream))))
          
 
 ;; EOF


### PR DESCRIPTION
All the symbols were external to sb-kernel.